### PR TITLE
Migrate icons from FontAwesome to astro-icon (Lucide + Simple Icons)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig, fontProviders } from 'astro/config';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import icon from 'astro-icon';
 import rehypeExternalLinks from 'rehype-external-links';
 import rehypeCodeBar from './src/plugins/rehypeCodeBar.mjs';
 
@@ -27,6 +28,7 @@ export default defineConfig({
   integrations: [
     mdx(),
     sitemap(),
+    icon(),
   ],
   markdown: {
     shikiConfig: {

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,10 @@
         "@astrojs/check": "0.9.8",
         "@astrojs/mdx": "5.0.3",
         "@astrojs/sitemap": "3.7.2",
+        "@iconify-json/lucide": "^1.2.102",
+        "@iconify-json/simple-icons": "^1.2.78",
         "astro": "6.1.2",
+        "astro-icon": "^1.1.5",
         "rehype-external-links": "^3.0.0",
         "sass": "^1.97.3",
         "typescript": "^5.9.3",
@@ -26,6 +29,10 @@
     },
   },
   "packages": {
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@antfu/utils": ["@antfu/utils@8.1.1", "", {}, "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ=="],
+
     "@astrojs/check": ["@astrojs/check@0.9.8", "", { "dependencies": { "@astrojs/language-server": "^2.16.5", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw=="],
 
     "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
@@ -128,6 +135,16 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
+    "@iconify-json/lucide": ["@iconify-json/lucide@1.2.102", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-Dm3EEqu5NrmzyDMB2U1+8yroEj2/dB9V4KlH0m/szwwF/ofSf0cPaGTZqkd1aExXjCor+vU53ttRMCGuXf+/cg=="],
+
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.78", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ=="],
+
+    "@iconify/tools": ["@iconify/tools@4.2.0", "", { "dependencies": { "@iconify/types": "^2.0.0", "@iconify/utils": "^2.3.0", "cheerio": "^1.1.2", "domhandler": "^5.0.3", "extract-zip": "^2.0.1", "local-pkg": "^1.1.2", "pathe": "^2.0.3", "svgo": "^3.3.2", "tar": "^7.5.2" } }, "sha512-WRxPva/ipxYkqZd1+CkEAQmd86dQmrwH0vwK89gmp2Kh2WyyVw57XbPng0NehP3x4V1LzLsXUneP1uMfTMZmUA=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@2.3.0", "", { "dependencies": { "@antfu/install-pkg": "^1.0.0", "@antfu/utils": "^8.1.0", "@iconify/types": "^2.0.0", "debug": "^4.4.0", "globals": "^15.14.0", "kolorist": "^1.8.0", "local-pkg": "^1.0.0", "mlly": "^1.7.4" } }, "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA=="],
+
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -177,6 +194,8 @@
     "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
 
     "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
@@ -328,6 +347,8 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
+
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
     "@volar/kit": ["@volar/kit@2.4.28", "", { "dependencies": { "@volar/language-service": "2.4.28", "@volar/typescript": "2.4.28", "typesafe-path": "^0.2.2", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "typescript": "*" } }, "sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg=="],
@@ -372,11 +393,15 @@
 
     "astro": ["astro@6.1.2", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.8.0", "@astrojs/markdown-remark": "7.1.0", "@astrojs/telemetry": "3.3.0", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dlv": "^1.1.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.3", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.4", "vfile": "^6.0.3", "vite": "^7.3.1", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-r3iIvmB6JvQxsdJLvapybKKq7Bojd1iQK6CCx5P55eRnXJIyUpHx/1UB/GdMm+em/lwaCUasxHCmIO0lCLV2uA=="],
 
+    "astro-icon": ["astro-icon@1.1.5", "", { "dependencies": { "@iconify/tools": "^4.0.5", "@iconify/types": "^2.0.0", "@iconify/utils": "^2.1.30" } }, "sha512-CJYS5nWOw9jz4RpGWmzNQY7D0y2ZZacH7atL2K9DeJXJVaz7/5WrxeyIxO8KASk1jCM96Q4LjRx/F3R+InjJrw=="],
+
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
+    "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
@@ -390,7 +415,13 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
@@ -409,6 +440,8 @@
     "commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
+
+    "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -458,6 +491,10 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
     "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
@@ -488,11 +525,17 @@
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fd-slicer": ["fd-slicer@1.1.0", "", { "dependencies": { "pend": "~1.2.0" } }, "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -508,7 +551,11 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
+
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "globals": ["globals@15.15.0", "", {}, "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg=="],
 
     "h3": ["h3@1.15.6", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-oi15ESLW5LRthZ+qPCi5GNasY/gvynSKUQxgiovrY63bPAtG59wtM+LSrlcwvOHAXzGrXVLnI97brbkdPF9WoQ=="],
 
@@ -540,7 +587,11 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "immutable": ["immutable@5.1.5", "", {}, "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A=="],
 
@@ -579,6 +630,10 @@
     "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
+
+    "local-pkg": ["local-pkg@1.1.2", "", { "dependencies": { "mlly": "^1.7.4", "pkg-types": "^2.3.0", "quansync": "^0.2.11" } }, "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -698,6 +753,12 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
+    "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -726,6 +787,8 @@
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
@@ -746,13 +809,23 @@
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -761,6 +834,10 @@
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
@@ -820,6 +897,8 @@
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "sass": ["sass@1.97.3", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg=="],
 
     "sax": ["sax@1.5.0", "", {}, "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA=="],
@@ -856,6 +935,8 @@
 
     "svgo": ["svgo@4.0.1", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w=="],
 
+    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tinyclip": ["tinyclip@0.1.12", "", {}, "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA=="],
@@ -883,6 +964,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
@@ -958,15 +1041,23 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
     "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -976,6 +1067,8 @@
 
     "yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
+    "yauzl": ["yauzl@2.10.0", "", { "dependencies": { "buffer-crc32": "~0.2.3", "fd-slicer": "~1.1.0" } }, "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g=="],
+
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -984,13 +1077,21 @@
 
     "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
+    "@iconify/tools/svgo": ["svgo@3.3.3", "", { "dependencies": { "commander": "^7.2.0", "css-select": "^5.1.0", "css-tree": "^2.3.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.0.0", "sax": "^1.5.0" }, "bin": "./bin/svgo" }, "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng=="],
+
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@types/yauzl/@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
     "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
@@ -1006,8 +1107,16 @@
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "@iconify/tools/svgo/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "@iconify/tools/svgo/css-tree": ["css-tree@2.3.1", "", { "dependencies": { "mdn-data": "2.0.30", "source-map-js": "^1.0.1" } }, "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw=="],
+
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 
+    "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "@iconify/tools/svgo/css-tree/mdn-data": ["mdn-data@2.0.30", "", {}, "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,10 @@
     "@astrojs/check": "0.9.8",
     "@astrojs/mdx": "5.0.3",
     "@astrojs/sitemap": "3.7.2",
+    "@iconify-json/lucide": "^1.2.102",
+    "@iconify-json/simple-icons": "^1.2.78",
     "astro": "6.1.2",
+    "astro-icon": "^1.1.5",
     "rehype-external-links": "^3.0.0",
     "sass": "^1.97.3",
     "typescript": "^5.9.3"

--- a/src/components/AuthorBox.astro
+++ b/src/components/AuthorBox.astro
@@ -1,5 +1,6 @@
 ---
 import { siteConfig } from '@/config';
+import { Icon } from 'astro-icon/components';
 ---
 
 <section class="author-box">
@@ -15,28 +16,28 @@ import { siteConfig } from '@/config';
       {siteConfig.email && (
         <li class="email">
           <a href={`mailto:${siteConfig.email}`} aria-label="Email">
-            <i class="fas fa-envelope"></i>
+            <Icon name="lucide:mail" />
           </a>
         </li>
       )}
       {siteConfig.website && (
         <li class="website">
           <a href={`http://${siteConfig.website}`} target="_blank" aria-label="Website">
-            <i class="fas fa-globe"></i>
+            <Icon name="lucide:globe" />
           </a>
         </li>
       )}
       {siteConfig.linkedin && (
         <li class="linkedin">
           <a href={`https://in.linkedin.com/in/${siteConfig.linkedin}`} target="_blank" aria-label="LinkedIn">
-            <i class="fab fa-linkedin"></i>
+            <Icon name="simple-icons:linkedin" />
           </a>
         </li>
       )}
       {siteConfig.twitter && (
         <li class="twitter">
           <a href={`https://twitter.com/${siteConfig.twitter}`} target="_blank" aria-label="Twitter">
-            <i class="fab fa-twitter"></i>
+            <Icon name="simple-icons:twitter" />
           </a>
         </li>
       )}

--- a/src/components/AuthorBox.astro
+++ b/src/components/AuthorBox.astro
@@ -16,28 +16,28 @@ import { Icon } from 'astro-icon/components';
       {siteConfig.email && (
         <li class="email">
           <a href={`mailto:${siteConfig.email}`} aria-label="Email">
-            <Icon name="lucide:mail" />
+            <Icon name="lucide:mail" aria-hidden="true" />
           </a>
         </li>
       )}
       {siteConfig.website && (
         <li class="website">
           <a href={`http://${siteConfig.website}`} target="_blank" aria-label="Website">
-            <Icon name="lucide:globe" />
+            <Icon name="lucide:globe" aria-hidden="true" />
           </a>
         </li>
       )}
       {siteConfig.linkedin && (
         <li class="linkedin">
           <a href={`https://in.linkedin.com/in/${siteConfig.linkedin}`} target="_blank" aria-label="LinkedIn">
-            <Icon name="simple-icons:linkedin" />
+            <Icon name="simple-icons:linkedin" aria-hidden="true" />
           </a>
         </li>
       )}
       {siteConfig.twitter && (
         <li class="twitter">
           <a href={`https://twitter.com/${siteConfig.twitter}`} target="_blank" aria-label="Twitter">
-            <Icon name="simple-icons:twitter" />
+            <Icon name="simple-icons:twitter" aria-hidden="true" />
           </a>
         </li>
       )}

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -59,9 +59,6 @@ const canonicalUrl = new URL(Astro.url.pathname, siteConfig.url);
   <Font cssVariable="--font-montserrat" preload />
   <Font cssVariable="--font-lato" preload />
 
-  <!-- Font Awesome -->
-  <script is:inline src="https://kit.fontawesome.com/f430ab3721.js" crossorigin="anonymous"></script>
-
   <!-- Dark mode toggle web component -->
   <script is:inline type="module" src="https://unpkg.com/dark-mode-toggle"></script>
 

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,6 @@
 ---
 import SubscribeModal from '@/components/SubscribeModal.astro';
+import { Icon } from 'astro-icon/components';
 ---
 
 <header class="main-header">
@@ -7,7 +8,7 @@ import SubscribeModal from '@/components/SubscribeModal.astro';
     <div class="header-flex">
       <div class="menu-icon-container">
         <button class="menu-icon" aria-label="Open menu" aria-expanded="false">
-          <i class="fas fa-bars" aria-hidden="true"></i>
+          <Icon name="lucide:menu" aria-hidden="true" />
         </button>
       </div>
       <p class="logo" style="margin:0;">
@@ -17,7 +18,7 @@ import SubscribeModal from '@/components/SubscribeModal.astro';
       </p>
       <nav class="main-nav">
         <button class="menu-icon-close" aria-label="Close menu">
-          <i class="fas fa-times" aria-hidden="true"></i>
+          <Icon name="lucide:x" aria-hidden="true" />
         </button>
         <ul>
           <li class="mobile-only"><a href="/">Blog</a></li>
@@ -33,7 +34,7 @@ import SubscribeModal from '@/components/SubscribeModal.astro';
       </nav>
       <div class="search-icon-container">
         <button class="search-icon" aria-label="Open search" aria-expanded="false">
-          <i class="fas fa-search" aria-hidden="true"></i>
+          <Icon name="lucide:search" aria-hidden="true" />
         </button>
         <dark-mode-toggle permanent></dark-mode-toggle>
       </div>

--- a/src/components/HeroPost.astro
+++ b/src/components/HeroPost.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import { getPostUrl } from '@/utils';
+import { Icon } from 'astro-icon/components';
 
 interface Props {
   post: CollectionEntry<'posts'>;
@@ -28,7 +29,7 @@ const category = post.data.tags?.[0] ?? null;
         </ul>
       )}
       <span class="hero-post__date">
-        <i class="far fa-clock"></i>
+        <Icon name="lucide:clock" aria-hidden="true" />
         <time datetime={post.data.date.toISOString()}>
           {post.data.date.toLocaleDateString('en-GB', {
             day: '2-digit',

--- a/src/components/Pagination.astro
+++ b/src/components/Pagination.astro
@@ -1,4 +1,6 @@
 ---
+import { Icon } from 'astro-icon/components';
+
 interface Props {
   previousUrl?: string;
   nextUrl?: string;
@@ -11,12 +13,12 @@ const { previousUrl, nextUrl } = Astro.props;
   <div class="pagination clearfix">
     {previousUrl && (
       <a href={previousUrl} class="previous">
-        <i class="fas fa-angle-left" aria-hidden="true"></i> Previous
+        <Icon name="lucide:chevron-left" aria-hidden="true" /> Previous
       </a>
     )}
     {nextUrl && (
       <a href={nextUrl} class="next">
-        Next <i class="fas fa-angle-right" aria-hidden="true"></i>
+        Next <Icon name="lucide:chevron-right" aria-hidden="true" />
       </a>
     )}
   </div>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -22,7 +22,7 @@ const { post, gridCard = false } = Astro.props;
     </a>
     <div class={gridCard ? 'post-card-body' : 'col-item post-card-body'}>
       <div>
-        <span>
+        <span class="post-date-wrapper">
           <Icon name="lucide:clock" aria-hidden="true" />
           <time class="post-date" datetime={post.data.date.toISOString()}>
             {post.data.date.toLocaleDateString('en-GB', {

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { CollectionEntry } from 'astro:content';
 import { getPostUrl } from '@/utils';
+import { Icon } from 'astro-icon/components';
 
 interface Props {
   post: CollectionEntry<'posts'>;
@@ -22,7 +23,7 @@ const { post, gridCard = false } = Astro.props;
     <div class={gridCard ? 'post-card-body' : 'col-item post-card-body'}>
       <div>
         <span>
-          <i class="far fa-clock"></i>
+          <Icon name="lucide:clock" aria-hidden="true" />
           <time class="post-date" datetime={post.data.date.toISOString()}>
             {post.data.date.toLocaleDateString('en-GB', {
               day: '2-digit',

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,4 +1,5 @@
 ---
+import { Icon } from 'astro-icon/components';
 ---
 
 <div class="search-box">
@@ -9,7 +10,7 @@
       </div>
       <div class="icon-close-container">
         <button class="search-icon-close" aria-label="Close search">
-          <i class="fas fa-times" aria-hidden="true"></i>
+          <Icon name="lucide:x" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/src/components/SubscribeModal.astro
+++ b/src/components/SubscribeModal.astro
@@ -1,11 +1,12 @@
 ---
 import SubscribeForm from '@/components/SubscribeForm.astro';
+import { Icon } from 'astro-icon/components';
 ---
 
 <div class="subscribe-modal" id="subscribe-modal" role="dialog" aria-modal="true" aria-labelledby="subscribe-modal-form-title">
   <div class="subscribe-modal__card">
     <button class="subscribe-modal__close" aria-label="Close subscribe dialog">
-      <i class="fas fa-times" aria-hidden="true"></i>
+      <Icon name="lucide:x" aria-hidden="true" />
     </button>
     <SubscribeForm formId="subscribe-modal-form" emailId="subscribe-modal-email" />
   </div>

--- a/src/components/UkraineBanner.astro
+++ b/src/components/UkraineBanner.astro
@@ -1,10 +1,11 @@
 ---
+import { Icon } from 'astro-icon/components';
 ---
 
 <div class="important-block">
   <span class="important-block__header">
     <strong>
-      <i class="fa fa-exclamation-circle" aria-hidden="true" style="font-size: 18px; margin-right: 5px;"></i>IMPORTANT
+      <Icon name="lucide:alert-circle" aria-hidden="true" size={18} style="margin-right: 5px;" />IMPORTANT
     </strong>
   </span>
   <br />

--- a/src/components/mdx/ImportantBlock.astro
+++ b/src/components/mdx/ImportantBlock.astro
@@ -1,4 +1,6 @@
 ---
+import { Icon } from 'astro-icon/components';
+
 interface Props {
   importantText?: string;
 }
@@ -9,7 +11,7 @@ const { importantText } = Astro.props;
 <div class="important-block">
   <span class="important-block__header">
     <strong>
-      <i class="fa fa-exclamation-circle" aria-hidden="true" style="font-size: 18px; margin-right: 5px;"></i>IMPORTANT
+      <Icon name="lucide:alert-circle" aria-hidden="true" size={18} style="margin-right: 5px;" />IMPORTANT
     </strong>
   </span>
   <br />

--- a/src/components/mdx/UpdateBlock.astro
+++ b/src/components/mdx/UpdateBlock.astro
@@ -1,4 +1,6 @@
 ---
+import { Icon } from 'astro-icon/components';
+
 interface Props {
   text?: string;
 }
@@ -9,7 +11,7 @@ const { text } = Astro.props;
 <div class="update-block">
   <span class="update-block__header">
     <strong>
-      <i class="fa fa-exclamation-circle" aria-hidden="true" style="font-size: 18px; margin-right: 5px;"></i>UPDATE
+      <Icon name="lucide:alert-circle" aria-hidden="true" size={18} style="margin-right: 5px;" />UPDATE
     </strong>
   </span>
   <br />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -27,23 +27,12 @@ const { title, description, image } = Astro.props;
     </div>
     <HeaderInteractions />
     <Analytics />
-    <!-- Preserve Font Awesome's dynamically injected styles across ClientRouter navigations -->
     <script is:inline>
       document.addEventListener('astro:before-swap', (event) => {
-        document.head.querySelectorAll('style').forEach((style) => {
-          if (style.textContent && style.textContent.includes('svg-inline--fa')) {
-            event.newDocument.head.appendChild(style.cloneNode(true));
-          }
-        });
         // Preserve dynamically injected Pagefind CSS link
         document.head.querySelectorAll('link[href="/pagefind/pagefind-ui.css"]').forEach((link) => {
           event.newDocument.head.appendChild(link.cloneNode(true));
         });
-      });
-      document.addEventListener('astro:page-load', () => {
-        if (window.FontAwesome) {
-          window.FontAwesome.dom.i2svg();
-        }
       });
     </script>
   </body>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -7,6 +7,7 @@ import Newsletter from '@/components/Newsletter.astro';
 import RecentPosts from '@/components/RecentPosts.astro';
 import Utterances from '@/components/Utterances.astro';
 import CopyCode from '@/components/CopyCode.astro';
+import { Icon } from 'astro-icon/components';
 
 interface Props {
   title: string;
@@ -64,7 +65,7 @@ const dateStr = date.toLocaleDateString('en-GB', {
                 rel="noreferrer"
                 target="_blank"
               >
-                <i class="fab fa-twitter" aria-hidden="true"></i>
+                <Icon name="simple-icons:twitter" aria-hidden="true" />
               </a>
               <a
                 href={`https://facebook.com/sharer.php?u=${encodeURIComponent(fullUrl)}`}
@@ -72,7 +73,7 @@ const dateStr = date.toLocaleDateString('en-GB', {
                 rel="noreferrer"
                 target="_blank"
               >
-                <i class="fab fa-facebook" aria-hidden="true"></i>
+                <Icon name="simple-icons:facebook" aria-hidden="true" />
               </a>
               <a
                 href={`https://www.linkedin.com/shareArticle?url=${encodeURIComponent(fullUrl)}`}
@@ -80,7 +81,7 @@ const dateStr = date.toLocaleDateString('en-GB', {
                 rel="noreferrer"
                 target="_blank"
               >
-                <i class="fab fa-linkedin" aria-hidden="true"></i>
+                <Icon name="simple-icons:linkedin" aria-hidden="true" />
               </a>
             </div>
           </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -19,36 +19,36 @@ import { Icon } from 'astro-icon/components';
         <ul class="contact-list">
           {siteConfig.email && (
             <li class="email">
-              <a href={`mailto:${siteConfig.email}`}>
-                <Icon name="lucide:mail" />
+              <a href={`mailto:${siteConfig.email}`} aria-label="Email">
+                <Icon name="lucide:mail" aria-hidden="true" />
               </a>
             </li>
           )}
           {siteConfig.website && (
             <li class="website">
-              <a href={`https://${siteConfig.website}`} target="_blank" rel="noopener noreferrer">
-                <Icon name="lucide:globe" />
+              <a href={`https://${siteConfig.website}`} target="_blank" rel="noopener noreferrer" aria-label="Website">
+                <Icon name="lucide:globe" aria-hidden="true" />
               </a>
             </li>
           )}
           {siteConfig.linkedin && (
             <li class="linkedin">
-              <a href={`https://www.linkedin.com/in/${siteConfig.linkedin}`} target="_blank" rel="noopener noreferrer">
-                <Icon name="simple-icons:linkedin" />
+              <a href={`https://www.linkedin.com/in/${siteConfig.linkedin}`} target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+                <Icon name="simple-icons:linkedin" aria-hidden="true" />
               </a>
             </li>
           )}
           {siteConfig.github && (
             <li class="github">
-              <a href={`https://github.com/${siteConfig.github}`} target="_blank" rel="noopener noreferrer">
-                <Icon name="simple-icons:github" />
+              <a href={`https://github.com/${siteConfig.github}`} target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <Icon name="simple-icons:github" aria-hidden="true" />
               </a>
             </li>
           )}
           {siteConfig.twitter && (
             <li class="twitter">
-              <a href={`https://twitter.com/${siteConfig.twitter}`} target="_blank" rel="noopener noreferrer">
-                <Icon name="simple-icons:twitter" />
+              <a href={`https://twitter.com/${siteConfig.twitter}`} target="_blank" rel="noopener noreferrer" aria-label="Twitter">
+                <Icon name="simple-icons:twitter" aria-hidden="true" />
               </a>
             </li>
           )}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,6 +1,7 @@
 ---
 import HomeLayout from '@/layouts/HomeLayout.astro';
 import { siteConfig } from '@/config';
+import { Icon } from 'astro-icon/components';
 ---
 
 <HomeLayout title="About" description="About Oleksandr Olashyn Power Platform Architect">
@@ -19,35 +20,35 @@ import { siteConfig } from '@/config';
           {siteConfig.email && (
             <li class="email">
               <a href={`mailto:${siteConfig.email}`}>
-                <i class="fas fa-envelope"></i>
+                <Icon name="lucide:mail" />
               </a>
             </li>
           )}
           {siteConfig.website && (
             <li class="website">
               <a href={`https://${siteConfig.website}`} target="_blank" rel="noopener noreferrer">
-                <i class="fas fa-globe"></i>
+                <Icon name="lucide:globe" />
               </a>
             </li>
           )}
           {siteConfig.linkedin && (
             <li class="linkedin">
               <a href={`https://www.linkedin.com/in/${siteConfig.linkedin}`} target="_blank" rel="noopener noreferrer">
-                <i class="fab fa-linkedin"></i>
+                <Icon name="simple-icons:linkedin" />
               </a>
             </li>
           )}
           {siteConfig.github && (
             <li class="github">
               <a href={`https://github.com/${siteConfig.github}`} target="_blank" rel="noopener noreferrer">
-                <i class="fab fa-github"></i>
+                <Icon name="simple-icons:github" />
               </a>
             </li>
           )}
           {siteConfig.twitter && (
             <li class="twitter">
               <a href={`https://twitter.com/${siteConfig.twitter}`} target="_blank" rel="noopener noreferrer">
-                <i class="fab fa-twitter"></i>
+                <Icon name="simple-icons:twitter" />
               </a>
             </li>
           )}

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -15,7 +15,7 @@ import { Icon } from 'astro-icon/components';
           <div class="projects-header">
             <h2 class="projects-title">
               {project.title}
-              <a class="project-ext-link" href={project.extLink}>
+              <a class="project-ext-link" href={project.extLink} aria-label={`View ${project.title}`}>
                 <Icon name="lucide:external-link" aria-hidden="true" />
               </a>
             </h2>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,6 +1,7 @@
 ---
 import HomeLayout from '@/layouts/HomeLayout.astro';
 import { projects } from '@/data/projects';
+import { Icon } from 'astro-icon/components';
 ---
 
 <HomeLayout title="Projects">
@@ -15,7 +16,7 @@ import { projects } from '@/data/projects';
             <h2 class="projects-title">
               {project.title}
               <a class="project-ext-link" href={project.extLink}>
-                <i class="fas fa-external-link-alt" aria-hidden="true"></i>
+                <Icon name="lucide:external-link" aria-hidden="true" />
               </a>
             </h2>
           </div>

--- a/src/styles/partials/_hero-post.scss
+++ b/src/styles/partials/_hero-post.scss
@@ -57,9 +57,12 @@
     font-size: 0.85rem;
     color: var(--tag-date-color);
     white-space: nowrap;
+    display: flex;
+    align-items: center;
 
-    i {
+    svg {
       margin-right: 0.35rem;
+      flex-shrink: 0;
     }
   }
 

--- a/src/styles/partials/_pagination.scss
+++ b/src/styles/partials/_pagination.scss
@@ -7,6 +7,9 @@
     float: right;
   }
   .previous, .next {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
     text-decoration: none;
     text-transform: uppercase;
     font-size: 20px;

--- a/src/styles/partials/_pagination.scss
+++ b/src/styles/partials/_pagination.scss
@@ -9,7 +9,7 @@
   .previous, .next {
     display: inline-flex;
     align-items: center;
-    gap: 0.35rem;
+    gap: 0.15rem;
     text-decoration: none;
     text-transform: uppercase;
     font-size: 20px;

--- a/src/styles/partials/_pagination.scss
+++ b/src/styles/partials/_pagination.scss
@@ -15,8 +15,8 @@
     font-size: 20px;
     color: var(--link-color);
     svg {
-      width: 1em;
-      height: 1em;
+      width: 1.25em;
+      height: 1.25em;
     }
     &:hover {
       opacity: .8;

--- a/src/styles/partials/_pagination.scss
+++ b/src/styles/partials/_pagination.scss
@@ -14,6 +14,10 @@
     text-transform: uppercase;
     font-size: 20px;
     color: var(--link-color);
+    svg {
+      width: 1em;
+      height: 1em;
+    }
     &:hover {
       opacity: .8;
       color: var(--link-hover-color);

--- a/src/styles/partials/_pagination.scss
+++ b/src/styles/partials/_pagination.scss
@@ -15,8 +15,8 @@
     font-size: 20px;
     color: var(--link-color);
     svg {
-      width: 1.25em;
-      height: 1.25em;
+      width: 1.35em;
+      height: 1.35em;
     }
     &:hover {
       opacity: .8;

--- a/src/styles/partials/_post-card.scss
+++ b/src/styles/partials/_post-card.scss
@@ -45,8 +45,13 @@
   .post-card-body {
     padding: 1rem 1rem 1rem 2rem;
 
+    .post-date-wrapper {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
     .post-date{
-      margin-left: 10px;
     }
 
     .post-card-title{

--- a/src/styles/partials/_post-card.scss
+++ b/src/styles/partials/_post-card.scss
@@ -51,9 +51,6 @@
       gap: 0.35rem;
     }
 
-    .post-date{
-    }
-
     .post-card-title{
       text-decoration: none;
     }


### PR DESCRIPTION
## Why

The site was loading all icons via a FontAwesome Kit CDN script, which adds a runtime JS dependency, requires an external network request on every page load, and re-runs on every ClientRouter navigation. Switching to `astro-icon` inlines SVGs at build time -- zero runtime JS, no CDN, and only the icons actually used are shipped.

## What changed

**Packages added:** `astro-icon`, `@iconify-json/lucide`, `@iconify-json/simple-icons`

**All 13 distinct FontAwesome icons replaced** with `<Icon>` components across 12 source files:

| FontAwesome | New icon |
|---|---|
| `fa-envelope` | `lucide:mail` |
| `fa-globe` | `lucide:globe` |
| `fa-bars` | `lucide:menu` |
| `fa-times` | `lucide:x` |
| `fa-search` | `lucide:search` |
| `fa-clock` | `lucide:clock` |
| `fa-external-link-alt` | `lucide:external-link` |
| `fa-angle-left/right` | `lucide:chevron-left/right` |
| `fa-exclamation-circle` | `lucide:alert-circle` |
| `fab fa-linkedin` | `simple-icons:linkedin` |
| `fab fa-twitter` | `simple-icons:twitter` |
| `fab fa-github` | `simple-icons:github` |
| `fab fa-facebook` | `simple-icons:facebook` |

**Cleanup:**
- Removed the FontAwesome Kit `<script>` tag from `Head.astro`
- Removed the `astro:before-swap` FA style-preservation workaround and the `FontAwesome.dom.i2svg()` call from `BaseLayout.astro`

**Alignment fixes:** SVG icons don't inherit font-based vertical alignment like `<i>` tags did. Fixed affected components with flexbox:
- `_hero-post.scss` -- `__date` uses `display:flex; align-items:center`
- `_post-card.scss` -- added `post-date-wrapper` with `inline-flex; align-items:center`
- `_pagination.scss` -- `.previous/.next` use `inline-flex; align-items:center` with icon sized to `1.35em`