### PR TITLE
fix: skip recent posts section in pagefind search index

### DIFF
--- a/src/components/RecentPosts.astro
+++ b/src/components/RecentPosts.astro
@@ -8,7 +8,7 @@ const recentPosts = allPosts
   .slice(0, 4);
 ---
 
-<div class="recent-box">
+<div class="recent-box" data-pagefind-ignore>
   <h2 class="recent-title">Recent post</h2>
   <div class="recent-list">
     {recentPosts.map((post) => (


### PR DESCRIPTION
The "Recent post" sidebar section was being indexed by pagefind, causing its content to bleed into search results for unrelated posts. Searching for a term would return results with excerpts showing "Recent post. Switching from Jekyll to Astro..." even when the actual post had nothing to do with the query.

The fix adds `data-pagefind-ignore` to the wrapper `<div>` in `RecentPosts.astro`, which tells pagefind to skip that entire section when building the search index.